### PR TITLE
Updated thread state tracking, added definitions for mutex implementation.

### DIFF
--- a/runtime/src/include/45/ompt.h.var
+++ b/runtime/src/include/45/ompt.h.var
@@ -34,7 +34,7 @@
     macro(ompt_get_place_proc_ids)          \
     macro(ompt_get_place_num)               \
     macro(ompt_get_partition_place_nums)    \
-    macro(ompt_get_proc_id)               
+    macro(ompt_get_proc_id)
 
 #define FOREACH_OMPT_PLACEHOLDER_FN(macro)  \
     macro (ompt_idle)                       \
@@ -43,42 +43,46 @@
     macro (ompt_task_wait)                  \
     macro (ompt_mutex_wait)
 
-#define FOREACH_OMPT_STATE(macro)                                                               \
+#define FOREACH_OMP_STATE(macro)                                                                \
                                                                                                 \
-    /* first */                                                                                 \
-    macro (ompt_state_first, 0x71)          /* initial enumeration state */                     \
+    /* first available state */                                                                 \
+    macro (omp_state_undefined, 0x102)      /* undefined thread state */                        \
                                                                                                 \
     /* work states (0..15) */                                                                   \
-    macro (ompt_state_work_serial, 0x00)    /* working outside parallel */                      \
-    macro (ompt_state_work_parallel, 0x01)  /* working within parallel */                       \
-    macro (ompt_state_work_reduction, 0x02) /* performing a reduction */                        \
+    macro (omp_state_work_serial, 0x000)    /* working outside parallel */                      \
+    macro (omp_state_work_parallel, 0x001)  /* working within parallel */                       \
+    macro (omp_state_work_reduction, 0x002) /* performing a reduction */                        \
                                                                                                 \
-    /* idle (16..31) */                                                                         \
-    macro (ompt_state_idle, 0x10)            /* waiting for work */                             \
+    /* barrier wait states (16..31) */                                                          \
+    macro (omp_state_wait_barrier, 0x010)   /* waiting at a barrier */                          \
+    macro (omp_state_wait_barrier_implicit_parallel, 0x011)                                     \
+                                            /* implicit barrier at the end of parallel region */\
+    macro (omp_state_wait_barrier_implicit_workshare, 0x012)                                    \
+                                            /* implicit barrier at the end of worksharing */    \
+    macro (omp_state_wait_barrier_implicit, 0x013)  /* implicit barrier */                      \
+    macro (omp_state_wait_barrier_explicit, 0x014)  /* explicit barrier */                      \
                                                                                                 \
-    /* overhead states (32..63) */                                                              \
-    macro (ompt_state_overhead, 0x20)        /* overhead excluding wait states */               \
+    /* task wait states (32..63) */                                                             \
+    macro (omp_state_wait_taskwait, 0x020)  /* waiting at a taskwait */                         \
+    macro (omp_state_wait_taskgroup, 0x021) /* waiting at a taskgroup */                        \
                                                                                                 \
-    /* barrier wait states (64..79) */                                                          \
-    macro (ompt_state_wait_barrier, 0x40)    /* waiting at a barrier */                         \
-    macro (ompt_state_wait_barrier_implicit, 0x41)    /* implicit barrier */                    \
-    macro (ompt_state_wait_barrier_explicit, 0x42)    /* explicit barrier */                    \
+    /* mutex wait states (64..127) */                                                           \
+    macro (omp_state_wait_mutex, 0x040)                                                         \
+    macro (omp_state_wait_lock, 0x041)      /* waiting for lock */                              \
+    macro (omp_state_wait_critical, 0x042)  /* waiting for critical */                          \
+    macro (omp_state_wait_atomic, 0x043)    /* waiting for atomic */                            \
+    macro (omp_state_wait_ordered, 0x044)   /* waiting for ordered */                           \
                                                                                                 \
-    /* task wait states (80..95) */                                                             \
-    macro (ompt_state_wait_taskwait, 0x50)   /* waiting at a taskwait */                        \
-    macro (ompt_state_wait_taskgroup, 0x51)  /* waiting at a taskgroup */                       \
+    /* target wait states (128..255) */                                                         \
+    macro (omp_state_wait_target, 0x080)        /* waiting for critical */                      \
+    macro (omp_state_wait_target_map, 0x081)    /* waiting for atomic */                        \
+    macro (omp_state_wait_target_update, 0x082) /* waiting for ordered */                       \
                                                                                                 \
-    /* mutex wait states (96..111) */                                                           \
-    macro (ompt_state_wait_lock, 0x60)       /* waiting for lock */                             \
-    macro (ompt_state_wait_nest_lock, 0x61)  /* waiting for nest lock */                        \
-    macro (ompt_state_wait_critical, 0x62)   /* waiting for critical */                         \
-    macro (ompt_state_wait_atomic, 0x63)     /* waiting for atomic */                           \
-    macro (ompt_state_wait_ordered, 0x64)    /* waiting for ordered */                          \
-    macro (ompt_state_wait_single, 0x6F)     /* waiting for single region (non-standard!) */    \
+    /* misc (256..511) */                                                                       \
+    macro (omp_state_idle, 0x100)           /* waiting for work */                              \
+    macro (omp_state_overhead, 0x101)       /* overhead excluding wait states */                \
                                                                                                 \
-    /* misc (112..127) */                                                                       \
-    macro (ompt_state_undefined, 0x70)       /* undefined thread state */
-
+    /* implementation-specific states (512..) */
 
 #define FOREACH_OMPT_EVENT(macro)                                                                               \
                                                                                                                 \
@@ -116,7 +120,7 @@
     macro (ompt_callback_work,                  ompt_callback_work_t,          18) /* task at work begin or end*/\
                                                                                                                 \
     macro (ompt_callback_master,                ompt_callback_master_t,        19) /* task at master begin or end */\
-    														                                                    \
+                                                                                                                \
     /*macro (ompt_callback_target_map,            ompt_callback_target_map_t,    20)*/ /* target map */             \
                                                                                                                 \
     macro (ompt_callback_sync_region,           ompt_callback_sync_region_t,   21) /* sync region begin or end */ \
@@ -131,7 +135,9 @@
                                                                                                                 \
     macro (ompt_callback_flush,                 ompt_callback_flush_t,         27) /* after executing flush */  \
                                                                                                                 \
-    macro (ompt_callback_cancel, 		        ompt_callback_cancel_t,        28) /*cancel innermost binding region*/\
+    macro (ompt_callback_cancel,                ompt_callback_cancel_t,        28) /*cancel innermost binding region*/\
+
+
 
 /*****************************************************************************
  * data types
@@ -198,10 +204,10 @@ typedef struct ompt_task_dependence_s {
  *---------------------*/
 
 typedef enum {
-#define ompt_state_macro(state, code) state = code,
-    FOREACH_OMPT_STATE(ompt_state_macro)
-#undef ompt_state_macro
-} ompt_state_t;
+#define omp_state_macro(state, code) state = code,
+    FOREACH_OMP_STATE(omp_state_macro)
+#undef omp_state_macro
+} omp_state_t;
 
 
 /*---------------------
@@ -219,11 +225,11 @@ typedef enum ompt_callbacks_e{
  * set callback results
  *---------------------*/
 typedef enum ompt_set_result_e {
-	ompt_set_error = 0,
-	ompt_set_never = 1,
-	ompt_set_sometimes = 2,
-	ompt_set_sometimes_paired = 3,
-	ompt_set_always = 4
+    ompt_set_error = 0,
+    ompt_set_never = 1,
+    ompt_set_sometimes = 2,
+    ompt_set_sometimes_paired = 3,
+    ompt_set_always = 4
 } ompt_set_result_t;
 
 
@@ -459,7 +465,7 @@ typedef void (*ompt_callback_sync_region_t) (
 typedef enum ompt_cancel_flag_e {
     ompt_cancel_parallel       = 0x1,
     ompt_cancel_sections       = 0x2,
-    ompt_cancel_do	           = 0x4,
+    ompt_cancel_do             = 0x4,
     ompt_cancel_taskgroup      = 0x8,
     ompt_cancel_activated      = 0x10,
     ompt_cancel_detected       = 0x20,
@@ -497,7 +503,7 @@ extern "C" {
  ***************************************************************************/
 
 /* state */
-OMPT_API_FUNCTION(ompt_state_t, ompt_get_state, (
+OMPT_API_FUNCTION(omp_state_t, ompt_get_state, (
     ompt_wait_id_t *wait_id
 ));
 

--- a/runtime/src/include/45/ompt.h.var
+++ b/runtime/src/include/45/ompt.h.var
@@ -19,6 +19,7 @@
 
 #define FOREACH_OMPT_INQUIRY_FN(macro)      \
     macro (ompt_enumerate_states)           \
+    macro (ompt_enumerate_mutex_impls)      \
                                             \
     macro (ompt_set_callback)               \
     macro (ompt_get_callback)               \
@@ -83,6 +84,13 @@
     macro (omp_state_overhead, 0x101)       /* overhead excluding wait states */                \
                                                                                                 \
     /* implementation-specific states (512..) */
+
+
+#define FOREACH_OMPT_MUTEX_IMPL(macro)                                                \
+    macro (ompt_mutex_impl_unknown, 0)      /* unknown implementatin */               \
+    macro (ompt_mutex_impl_spin, 1)         /* based on spin */                       \
+    macro (ompt_mutex_impl_queuing, 2)      /* based on some fair policy */           \
+    macro (ompt_mutex_impl_speculative, 3)  /* based on HW-supported speculation */
 
 #define FOREACH_OMPT_EVENT(macro)                                                                               \
                                                                                                                 \
@@ -232,6 +240,15 @@ typedef enum ompt_set_result_e {
     ompt_set_always = 4
 } ompt_set_result_t;
 
+
+/*----------------------
+ * mutex implementations
+ *----------------------*/
+typedef enum ompt_mutex_impl_e {
+#define ompt_mutex_impl_macro(impl, code) impl = code,
+    FOREACH_OMPT_MUTEX_IMPL(ompt_mutex_impl_macro)
+#undef ompt_mutex_impl_macro
+} ompt_mutex_impl_t;
 
 
 /*****************************************************************************
@@ -654,6 +671,13 @@ OMPT_API_FUNCTION(int, ompt_enumerate_states, (
     int current_state,
     int *next_state,
     const char **next_state_name
+));
+
+/* mutex implementation enumeration */
+OMPT_API_FUNCTION(int, ompt_enumerate_mutex_impls, (
+    int current_impl,
+    int *next_impl,
+    const char **next_impl_name
 ));
 
 /* get_unique_id */

--- a/runtime/src/include/50/ompt.h.var
+++ b/runtime/src/include/50/ompt.h.var
@@ -34,7 +34,7 @@
     macro(ompt_get_place_proc_ids)          \
     macro(ompt_get_place_num)               \
     macro(ompt_get_partition_place_nums)    \
-    macro(ompt_get_proc_id)               
+    macro(ompt_get_proc_id)
 
 #define FOREACH_OMPT_PLACEHOLDER_FN(macro)  \
     macro (ompt_idle)                       \
@@ -43,42 +43,46 @@
     macro (ompt_task_wait)                  \
     macro (ompt_mutex_wait)
 
-#define FOREACH_OMPT_STATE(macro)                                                               \
+#define FOREACH_OMP_STATE(macro)                                                                \
                                                                                                 \
-    /* first */                                                                                 \
-    macro (ompt_state_first, 0x71)          /* initial enumeration state */                     \
+    /* first available state */                                                                 \
+    macro (omp_state_undefined, 0x102)      /* undefined thread state */                        \
                                                                                                 \
     /* work states (0..15) */                                                                   \
-    macro (ompt_state_work_serial, 0x00)    /* working outside parallel */                      \
-    macro (ompt_state_work_parallel, 0x01)  /* working within parallel */                       \
-    macro (ompt_state_work_reduction, 0x02) /* performing a reduction */                        \
+    macro (omp_state_work_serial, 0x000)    /* working outside parallel */                      \
+    macro (omp_state_work_parallel, 0x001)  /* working within parallel */                       \
+    macro (omp_state_work_reduction, 0x002) /* performing a reduction */                        \
                                                                                                 \
-    /* idle (16..31) */                                                                         \
-    macro (ompt_state_idle, 0x10)            /* waiting for work */                             \
+    /* barrier wait states (16..31) */                                                          \
+    macro (omp_state_wait_barrier, 0x010)   /* waiting at a barrier */                          \
+    macro (omp_state_wait_barrier_implicit_parallel, 0x011)                                     \
+                                            /* implicit barrier at the end of parallel region */\
+    macro (omp_state_wait_barrier_implicit_workshare, 0x012)                                    \
+                                            /* implicit barrier at the end of worksharing */    \
+    macro (omp_state_wait_barrier_implicit, 0x013)  /* implicit barrier */                      \
+    macro (omp_state_wait_barrier_explicit, 0x014)  /* explicit barrier */                      \
                                                                                                 \
-    /* overhead states (32..63) */                                                              \
-    macro (ompt_state_overhead, 0x20)        /* overhead excluding wait states */               \
+    /* task wait states (32..63) */                                                             \
+    macro (omp_state_wait_taskwait, 0x020)  /* waiting at a taskwait */                         \
+    macro (omp_state_wait_taskgroup, 0x021) /* waiting at a taskgroup */                        \
                                                                                                 \
-    /* barrier wait states (64..79) */                                                          \
-    macro (ompt_state_wait_barrier, 0x40)    /* waiting at a barrier */                         \
-    macro (ompt_state_wait_barrier_implicit, 0x41)    /* implicit barrier */                    \
-    macro (ompt_state_wait_barrier_explicit, 0x42)    /* explicit barrier */                    \
+    /* mutex wait states (64..127) */                                                           \
+    macro (omp_state_wait_mutex, 0x040)                                                         \
+    macro (omp_state_wait_lock, 0x041)      /* waiting for lock */                              \
+    macro (omp_state_wait_critical, 0x042)  /* waiting for critical */                          \
+    macro (omp_state_wait_atomic, 0x043)    /* waiting for atomic */                            \
+    macro (omp_state_wait_ordered, 0x044)   /* waiting for ordered */                           \
                                                                                                 \
-    /* task wait states (80..95) */                                                             \
-    macro (ompt_state_wait_taskwait, 0x50)   /* waiting at a taskwait */                        \
-    macro (ompt_state_wait_taskgroup, 0x51)  /* waiting at a taskgroup */                       \
+    /* target wait states (128..255) */                                                         \
+    macro (omp_state_wait_target, 0x080)        /* waiting for critical */                      \
+    macro (omp_state_wait_target_map, 0x081)    /* waiting for atomic */                        \
+    macro (omp_state_wait_target_update, 0x082) /* waiting for ordered */                       \
                                                                                                 \
-    /* mutex wait states (96..111) */                                                           \
-    macro (ompt_state_wait_lock, 0x60)       /* waiting for lock */                             \
-    macro (ompt_state_wait_nest_lock, 0x61)  /* waiting for nest lock */                        \
-    macro (ompt_state_wait_critical, 0x62)   /* waiting for critical */                         \
-    macro (ompt_state_wait_atomic, 0x63)     /* waiting for atomic */                           \
-    macro (ompt_state_wait_ordered, 0x64)    /* waiting for ordered */                          \
-    macro (ompt_state_wait_single, 0x6F)     /* waiting for single region (non-standard!) */    \
+    /* misc (256..511) */                                                                       \
+    macro (omp_state_idle, 0x100)           /* waiting for work */                              \
+    macro (omp_state_overhead, 0x101)       /* overhead excluding wait states */                \
                                                                                                 \
-    /* misc (112..127) */                                                                       \
-    macro (ompt_state_undefined, 0x70)       /* undefined thread state */
-
+    /* implementation-specific states (512..) */
 
 #define FOREACH_OMPT_EVENT(macro)                                                                               \
                                                                                                                 \
@@ -200,10 +204,10 @@ typedef struct ompt_task_dependence_s {
  *---------------------*/
 
 typedef enum {
-#define ompt_state_macro(state, code) state = code,
-    FOREACH_OMPT_STATE(ompt_state_macro)
-#undef ompt_state_macro
-} ompt_state_t;
+#define omp_state_macro(state, code) state = code,
+    FOREACH_OMP_STATE(omp_state_macro)
+#undef omp_state_macro
+} omp_state_t;
 
 
 /*---------------------
@@ -499,7 +503,7 @@ extern "C" {
  ***************************************************************************/
 
 /* state */
-OMPT_API_FUNCTION(ompt_state_t, ompt_get_state, (
+OMPT_API_FUNCTION(omp_state_t, ompt_get_state, (
     ompt_wait_id_t *wait_id
 ));
 

--- a/runtime/src/include/50/ompt.h.var
+++ b/runtime/src/include/50/ompt.h.var
@@ -19,6 +19,7 @@
 
 #define FOREACH_OMPT_INQUIRY_FN(macro)      \
     macro (ompt_enumerate_states)           \
+    macro (ompt_enumerate_mutex_impls)      \
                                             \
     macro (ompt_set_callback)               \
     macro (ompt_get_callback)               \
@@ -83,6 +84,13 @@
     macro (omp_state_overhead, 0x101)       /* overhead excluding wait states */                \
                                                                                                 \
     /* implementation-specific states (512..) */
+
+
+#define FOREACH_OMPT_MUTEX_IMPL(macro)                                                \
+    macro (ompt_mutex_impl_unknown, 0)      /* unknown implementatin */               \
+    macro (ompt_mutex_impl_spin, 1)         /* based on spin */                       \
+    macro (ompt_mutex_impl_queuing, 2)      /* based on some fair policy */           \
+    macro (ompt_mutex_impl_speculative, 3)  /* based on HW-supported speculation */
 
 #define FOREACH_OMPT_EVENT(macro)                                                                               \
                                                                                                                 \
@@ -232,6 +240,15 @@ typedef enum ompt_set_result_e {
     ompt_set_always = 4
 } ompt_set_result_t;
 
+
+/*----------------------
+ * mutex implementations
+ *----------------------*/
+typedef enum ompt_mutex_impl_e {
+#define ompt_mutex_impl_macro(impl, code) impl = code,
+    FOREACH_OMPT_MUTEX_IMPL(ompt_mutex_impl_macro)
+#undef ompt_mutex_impl_macro
+} ompt_mutex_impl_t;
 
 
 /*****************************************************************************
@@ -654,6 +671,13 @@ OMPT_API_FUNCTION(int, ompt_enumerate_states, (
     int current_state,
     int *next_state,
     const char **next_state_name
+));
+
+/* mutex implementation enumeration */
+OMPT_API_FUNCTION(int, ompt_enumerate_mutex_impls, (
+    int current_impl,
+    int *next_impl,
+    const char **next_impl_name
 ));
 
 /* get_unique_id */

--- a/runtime/src/kmp_atomic.h
+++ b/runtime/src/kmp_atomic.h
@@ -382,8 +382,8 @@ __kmp_acquire_atomic_lock( kmp_atomic_lock_t *lck, kmp_int32 gtid )
         ompt_callbacks.ompt_callback(ompt_callback_mutex_acquire)) {
         ompt_callbacks.ompt_callback(ompt_callback_mutex_acquire)(
             ompt_mutex_atomic,
-            0, 
-            0, //TODO for intel: specify impl
+            0,
+            ompt_mutex_impl_queuing,
             (ompt_wait_id_t) lck,
             OMPT_GET_RETURN_ADDRESS(0));
     }

--- a/runtime/src/kmp_barrier.cpp
+++ b/runtime/src/kmp_barrier.cpp
@@ -1132,7 +1132,7 @@ __kmp_barrier(enum barrier_type bt, int gtid, int is_split, size_t reduce_size,
         // It is OK to report the barrier state after the barrier begin callback.
         // According to the OMPT specification, a compliant implementation may
         // even delay reporting this state until the barrier begins to wait.
-        this_thr->th.ompt_thread_info.state = ompt_state_wait_barrier;
+        this_thr->th.ompt_thread_info.state = omp_state_wait_barrier;
     }
 #endif
 
@@ -1361,7 +1361,7 @@ __kmp_barrier(enum barrier_type bt, int gtid, int is_split, size_t reduce_size,
                 return_address);
         }
 #endif
-        this_thr->th.ompt_thread_info.state = ompt_state_work_parallel;
+        this_thr->th.ompt_thread_info.state = omp_state_work_parallel;
     }
 #endif
     ANNOTATE_BARRIER_END(&team->t.t_bar);
@@ -1486,7 +1486,7 @@ __kmp_join_barrier(int gtid)
                 OMPT_GET_RETURN_ADDRESS(1));
         }
 #endif
-        this_thr->th.ompt_thread_info.state = ompt_state_wait_barrier_implicit;
+        this_thr->th.ompt_thread_info.state = omp_state_wait_barrier_implicit;
     }
 #endif
 
@@ -1655,7 +1655,7 @@ __kmp_fork_barrier(int gtid, int tid)
         task_info->frame.exit_runtime_frame = NULL;
     }
 #endif
-    this_thr->th.ompt_thread_info.state = ompt_state_wait_barrier_implicit;
+    this_thr->th.ompt_thread_info.state = omp_state_wait_barrier_implicit;
 #endif
     if (team)
       ANNOTATE_BARRIER_END(&team->t.t_bar);
@@ -1737,12 +1737,12 @@ __kmp_fork_barrier(int gtid, int tid)
 #if OMPT_SUPPORT
     if(ompt_enabled)
     {
-        if (this_thr->th.ompt_thread_info.state == ompt_state_wait_barrier_implicit) {
+        if (this_thr->th.ompt_thread_info.state == omp_state_wait_barrier_implicit) {
             int ds_tid = this_thr->th.th_info.ds.ds_tid;
             ompt_task_data_t* tId = (team)? &(this_thr->th.th_current_task->ompt_task_info.task_data) : &(this_thr->th.ompt_thread_info.task_data);
 //            ompt_parallel_data_t* pId = (team)? &(team->t.ompt_team_info.parallel_data) : &(this_thr->th.ompt_thread_info.parallel_data);
             ompt_parallel_data_t* pId = (team)? &(team->t.ompt_team_info.parallel_data) : NULL;
-            this_thr->th.ompt_thread_info.state = ompt_state_overhead;
+            this_thr->th.ompt_thread_info.state = omp_state_overhead;
 #if OMPT_OPTIONAL
             void * codeptr = NULL;
             if (KMP_MASTER_TID(ds_tid) && (ompt_callbacks.ompt_callback(ompt_callback_sync_region_wait) || ompt_callbacks.ompt_callback(ompt_callback_sync_region)))
@@ -1775,7 +1775,7 @@ __kmp_fork_barrier(int gtid, int tid)
                     ds_tid);
             }
             // return to idle state
-            this_thr->th.ompt_thread_info.state = ompt_state_overhead;
+            this_thr->th.ompt_thread_info.state = omp_state_overhead;
         }
         
     }

--- a/runtime/src/kmp_csupport.cpp
+++ b/runtime/src/kmp_csupport.cpp
@@ -898,7 +898,7 @@ __kmpc_ordered( ident_t * loc, kmp_int32 gtid )
             ompt_callbacks.ompt_callback(ompt_callback_mutex_acquire)(
                 ompt_mutex_ordered,
                 omp_lock_hint_none,
-                0, //TODO for intel: specify impl
+                ompt_mutex_impl_spin,
                 (ompt_wait_id_t) lck,
                 OMPT_GET_RETURN_ADDRESS(0));
         }
@@ -1223,7 +1223,7 @@ __kmpc_critical( ident_t * loc, kmp_int32 global_tid, kmp_critical_name * crit )
             ompt_callbacks.ompt_callback(ompt_callback_mutex_acquire)(
             ompt_mutex_critical,
             omp_lock_hint_none,
-            0, //TODO for intel: specify impl
+            ompt_mutex_impl_unknown,
             (ompt_wait_id_t) crit,
             OMPT_GET_RETURN_ADDRESS(0));
         }
@@ -1303,6 +1303,53 @@ __kmp_map_hint_to_lock(uintptr_t hint)
     return __kmp_user_lock_seq;
 }
 
+#if OMPT_SUPPORT && OMPT_OPTIONAL
+ompt_mutex_impl_t
+__ompt_get_mutex_impl_type(void *user_lock, kmp_indirect_lock_t *ilock = 0)
+{
+    if (user_lock) {
+        switch (KMP_EXTRACT_D_TAG(user_lock)) {
+            case 0:
+                break;
+    #if KMP_USE_FUTEX
+            case locktag_futex:
+    #endif
+            case locktag_tas:
+                return ompt_mutex_impl_spin;
+    #if KMP_USE_TSX
+            case locktag_hle:
+                return ompt_mutex_impl_speculative;
+    #endif
+            default:
+                return ompt_mutex_impl_unknown;
+        }
+        ilock = KMP_LOOKUP_I_LOCK(user_lock);
+    }
+    KMP_ASSERT(ilock);
+    switch (ilock->type) {
+#if KMP_USE_TSX
+        case locktag_adaptive:
+        case locktag_rtm:
+            return ompt_mutex_impl_speculative;
+#endif
+#if KMP_USE_FUTEX
+        case locktag_nested_futex:
+#endif
+        case locktag_nested_tas:
+            return ompt_mutex_impl_spin;
+        case locktag_ticket:
+        case locktag_queuing:
+        case locktag_drdpa:
+        case locktag_nested_ticket:
+        case locktag_nested_queuing:
+        case locktag_nested_drdpa:
+            return ompt_mutex_impl_queuing;
+        default:
+            return ompt_mutex_impl_unknown;
+    }
+}
+#endif
+
 /*!
 @ingroup WORK_SHARING
 @param loc  source location information.
@@ -1360,7 +1407,7 @@ __kmpc_critical_with_hint( ident_t * loc, kmp_int32 global_tid, kmp_critical_nam
                 ompt_callbacks.ompt_callback(ompt_callback_mutex_acquire)(
                 ompt_mutex_critical,
                 (unsigned int)hint,
-                0, //TODO for intel: specify impl
+                __ompt_get_mutex_impl_type(crit),
                 (ompt_wait_id_t) crit,
                 OMPT_GET_RETURN_ADDRESS(0));
             }
@@ -1400,7 +1447,7 @@ __kmpc_critical_with_hint( ident_t * loc, kmp_int32 global_tid, kmp_critical_nam
                 ompt_callbacks.ompt_callback(ompt_callback_mutex_acquire)(
                 ompt_mutex_critical,
                 (unsigned int)hint,
-                0, //TODO for intel: specify impl
+                __ompt_get_mutex_impl_type(0, ilk),
                 (ompt_wait_id_t) crit,
                 OMPT_GET_RETURN_ADDRESS(0));
             }
@@ -2070,34 +2117,11 @@ __kmp_init_lock_with_hint(ident_t *loc, void **lock, kmp_dyna_lockseq_t seq)
 #if USE_ITT_BUILD
         __kmp_itt_lock_creating((kmp_user_lock_p)lock, NULL);
 #endif
-#if OMPT_SUPPORT && OMPT_OPTIONAL
-    if (ompt_enabled &&
-        ompt_callbacks.ompt_callback(ompt_callback_lock_init)) {
-        ompt_callbacks.ompt_callback(ompt_callback_lock_init)(
-            ompt_mutex_lock,
-            omp_lock_hint_none,
-            0,
-            (ompt_wait_id_t) lock,
-            OMPT_GET_RETURN_ADDRESS(0));
-    }
-#endif
     } else {
         KMP_INIT_I_LOCK(lock, seq);
 #if USE_ITT_BUILD
         kmp_indirect_lock_t *ilk = KMP_LOOKUP_I_LOCK(lock);
         __kmp_itt_lock_creating(ilk->lock, loc);
-#endif
-#if OMPT_SUPPORT && OMPT_OPTIONAL
-    if (ompt_enabled &&
-        ompt_callbacks.ompt_callback(ompt_callback_lock_init)) {
-        kmp_indirect_lock_t *ilk = KMP_LOOKUP_I_LOCK(lock);
-        ompt_callbacks.ompt_callback(ompt_callback_lock_init)(
-            ompt_mutex_lock,
-            omp_lock_hint_none,
-            0,
-            (ompt_wait_id_t) lock,
-            OMPT_GET_RETURN_ADDRESS(0));
-    }
 #endif
     }
 }
@@ -2137,18 +2161,6 @@ __kmp_init_nest_lock_with_hint(ident_t *loc, void **lock, kmp_dyna_lockseq_t seq
     kmp_indirect_lock_t *ilk = KMP_LOOKUP_I_LOCK(lock);
     __kmp_itt_lock_creating(ilk->lock, loc);
 #endif
-#if OMPT_SUPPORT && OMPT_OPTIONAL
-    if (ompt_enabled &&
-        ompt_callbacks.ompt_callback(ompt_callback_lock_init)) {
-        kmp_indirect_lock_t *ilk = KMP_LOOKUP_I_LOCK(lock);
-        ompt_callbacks.ompt_callback(ompt_callback_lock_init)(
-            ompt_mutex_nest_lock,
-            omp_lock_hint_none,
-            0,
-            (ompt_wait_id_t) lock,
-            OMPT_GET_RETURN_ADDRESS(0));
-    }
-#endif
 }
 
 /* initialize the lock with a hint */
@@ -2159,8 +2171,19 @@ __kmpc_init_lock_with_hint(ident_t *loc, kmp_int32 gtid, void **user_lock, uintp
     if (__kmp_env_consistency_check && user_lock == NULL) {
         KMP_FATAL(LockIsUninitialized, "omp_init_lock_with_hint");
     }
-
     __kmp_init_lock_with_hint(loc, user_lock, __kmp_map_hint_to_lock(hint));
+
+#if OMPT_SUPPORT && OMPT_OPTIONAL
+    if (ompt_enabled &&
+        ompt_callbacks.ompt_callback(ompt_callback_lock_init)) {
+        ompt_callbacks.ompt_callback(ompt_callback_lock_init)(
+            ompt_mutex_lock,
+            (omp_lock_hint_t)hint,
+            __ompt_get_mutex_impl_type(user_lock),
+            (ompt_wait_id_t)user_lock,
+            OMPT_GET_RETURN_ADDRESS(0));
+    }
+#endif
 }
 
 /* initialize the lock with a hint */
@@ -2173,6 +2196,18 @@ __kmpc_init_nest_lock_with_hint(ident_t *loc, kmp_int32 gtid, void **user_lock, 
     }
 
     __kmp_init_nest_lock_with_hint(loc, user_lock, __kmp_map_hint_to_lock(hint));
+
+#if OMPT_SUPPORT && OMPT_OPTIONAL
+    if (ompt_enabled &&
+        ompt_callbacks.ompt_callback(ompt_callback_lock_init)) {
+        ompt_callbacks.ompt_callback(ompt_callback_lock_init)(
+            ompt_mutex_nest_lock,
+            (omp_lock_hint_t)hint,
+            __ompt_get_mutex_impl_type(user_lock),
+            (ompt_wait_id_t)user_lock,
+            OMPT_GET_RETURN_ADDRESS(0));
+    }
+#endif
 }
 
 #endif // KMP_USE_DYNAMIC_LOCK
@@ -2186,6 +2221,18 @@ __kmpc_init_lock( ident_t * loc, kmp_int32 gtid,  void ** user_lock ) {
         KMP_FATAL(LockIsUninitialized, "omp_init_lock");
     }
     __kmp_init_lock_with_hint(loc, user_lock, __kmp_user_lock_seq);
+
+#if OMPT_SUPPORT && OMPT_OPTIONAL
+    if (ompt_enabled &&
+        ompt_callbacks.ompt_callback(ompt_callback_lock_init)) {
+        ompt_callbacks.ompt_callback(ompt_callback_lock_init)(
+            ompt_mutex_lock,
+            omp_lock_hint_none,
+            __ompt_get_mutex_impl_type(user_lock),
+            (ompt_wait_id_t)user_lock,
+            OMPT_GET_RETURN_ADDRESS(0));
+    }
+#endif
 
 #else // KMP_USE_DYNAMIC_LOCK
 
@@ -2223,7 +2270,7 @@ __kmpc_init_lock( ident_t * loc, kmp_int32 gtid,  void ** user_lock ) {
         ompt_callbacks.ompt_callback(ompt_callback_lock_init)(
             ompt_mutex_lock,
             omp_lock_hint_none,
-            0,
+            ompt_mutex_impl_unknown,
             (ompt_wait_id_t) user_lock,
             OMPT_GET_RETURN_ADDRESS(0));
     }
@@ -2246,6 +2293,18 @@ __kmpc_init_nest_lock( ident_t * loc, kmp_int32 gtid, void ** user_lock ) {
         KMP_FATAL(LockIsUninitialized, "omp_init_nest_lock");
     }
     __kmp_init_nest_lock_with_hint(loc, user_lock, __kmp_user_lock_seq);
+
+#if OMPT_SUPPORT && OMPT_OPTIONAL
+    if (ompt_enabled &&
+        ompt_callbacks.ompt_callback(ompt_callback_lock_init)) {
+        ompt_callbacks.ompt_callback(ompt_callback_lock_init)(
+            ompt_mutex_lock,
+            omp_lock_hint_none,
+            __ompt_get_mutex_impl_type(user_lock),
+            (ompt_wait_id_t)user_lock,
+            OMPT_GET_RETURN_ADDRESS(0));
+    }
+#endif
 
 #else // KMP_USE_DYNAMIC_LOCK
 
@@ -2285,7 +2344,7 @@ __kmpc_init_nest_lock( ident_t * loc, kmp_int32 gtid, void ** user_lock ) {
         ompt_callbacks.ompt_callback(ompt_callback_lock_init)(
             ompt_mutex_nest_lock,
             omp_lock_hint_none,
-            0,
+            ompt_mutex_impl_unknown,
             (ompt_wait_id_t) user_lock,
             OMPT_GET_RETURN_ADDRESS(0));
     }
@@ -2461,8 +2520,8 @@ __kmpc_set_lock( ident_t * loc, kmp_int32 gtid, void ** user_lock ) {
         ompt_callbacks.ompt_callback(ompt_callback_mutex_acquire)(
             ompt_mutex_lock,
             omp_lock_hint_none,
-            0, //TODO for intel: specify impl
-            (ompt_wait_id_t) user_lock,
+            __ompt_get_mutex_impl_type(user_lock),
+            (ompt_wait_id_t)user_lock,
             OMPT_GET_RETURN_ADDRESS(0));
     }
 #endif
@@ -2486,7 +2545,7 @@ __kmpc_set_lock( ident_t * loc, kmp_int32 gtid, void ** user_lock ) {
         ompt_callbacks.ompt_callback(ompt_callback_mutex_acquired)) {
         ompt_callbacks.ompt_callback(ompt_callback_mutex_acquired)(
             ompt_mutex_lock,
-            (ompt_wait_id_t) user_lock,
+            (ompt_wait_id_t)user_lock,
             OMPT_GET_RETURN_ADDRESS(0));
     }
 #endif
@@ -2518,7 +2577,7 @@ __kmpc_set_lock( ident_t * loc, kmp_int32 gtid, void ** user_lock ) {
         ompt_callbacks.ompt_callback(ompt_callback_mutex_acquire)(
             ompt_mutex_lock,
             omp_lock_hint_none,
-            0, //TODO for intel: specify impl
+            ompt_mutex_impl_unknown,
             (ompt_wait_id_t) lck,
             OMPT_GET_RETURN_ADDRESS(0));
     }
@@ -2556,8 +2615,8 @@ __kmpc_set_nest_lock( ident_t * loc, kmp_int32 gtid, void ** user_lock ) {
             ompt_callbacks.ompt_callback(ompt_callback_mutex_acquire)(
                 ompt_mutex_nest_lock,
                 omp_lock_hint_none,
-                0, //TODO for intel: specify impl
-                (ompt_wait_id_t) user_lock,
+                __ompt_get_mutex_impl_type(user_lock),
+                (ompt_wait_id_t)user_lock,
                 OMPT_GET_RETURN_ADDRESS(0));
         }
     }
@@ -2574,7 +2633,7 @@ __kmpc_set_nest_lock( ident_t * loc, kmp_int32 gtid, void ** user_lock ) {
                 //lock_first
                 ompt_callbacks.ompt_callback(ompt_callback_mutex_acquired)(
                     ompt_mutex_nest_lock,
-                    (ompt_wait_id_t) user_lock,
+                    (ompt_wait_id_t)user_lock,
                     OMPT_GET_RETURN_ADDRESS(0));
             }
         } else {
@@ -2582,7 +2641,7 @@ __kmpc_set_nest_lock( ident_t * loc, kmp_int32 gtid, void ** user_lock ) {
                 //lock_next
                 ompt_callbacks.ompt_callback(ompt_callback_nest_lock)(
                     ompt_scope_begin,
-                    (ompt_wait_id_t) user_lock,
+                    (ompt_wait_id_t)user_lock,
                     OMPT_GET_RETURN_ADDRESS(0));
             }
         }
@@ -2617,7 +2676,7 @@ __kmpc_set_nest_lock( ident_t * loc, kmp_int32 gtid, void ** user_lock ) {
             ompt_callbacks.ompt_callback(ompt_callback_mutex_acquire)(
                 ompt_mutex_nest_lock,
                 omp_lock_hint_none,
-                0, //TODO for intel: specify impl
+                ompt_mutex_impl_unknown,
                 (ompt_wait_id_t) lck,
                 OMPT_GET_RETURN_ADDRESS(0));
         }
@@ -2682,7 +2741,7 @@ __kmpc_unset_lock( ident_t *loc, kmp_int32 gtid, void **user_lock )
         ompt_callbacks.ompt_callback(ompt_callback_mutex_released)) {
         ompt_callbacks.ompt_callback(ompt_callback_mutex_released)(
             ompt_mutex_lock,
-            (ompt_wait_id_t) user_lock,
+            (ompt_wait_id_t)user_lock,
             OMPT_GET_RETURN_ADDRESS(0));
     }
 #endif
@@ -2889,8 +2948,8 @@ __kmpc_test_lock( ident_t *loc, kmp_int32 gtid, void **user_lock )
         ompt_callbacks.ompt_callback(ompt_callback_mutex_acquire)(
             ompt_mutex_lock,
             omp_lock_hint_none,
-            0, //TODO for intel: specify impl
-            (ompt_wait_id_t) user_lock,
+            __ompt_get_mutex_impl_type(user_lock),
+            (ompt_wait_id_t)user_lock,
             OMPT_GET_RETURN_ADDRESS(0));
     }
 #endif
@@ -2955,7 +3014,7 @@ __kmpc_test_lock( ident_t *loc, kmp_int32 gtid, void **user_lock )
         ompt_callbacks.ompt_callback(ompt_callback_mutex_acquire)(
             ompt_mutex_lock,
             omp_lock_hint_none,
-            0, //TODO for intel: specify impl
+            ompt_mutex_impl_unknown,
             (ompt_wait_id_t) lck,
             OMPT_GET_RETURN_ADDRESS(0));
     }
@@ -3067,7 +3126,7 @@ __kmpc_test_nest_lock( ident_t *loc, kmp_int32 gtid, void **user_lock )
         ompt_callbacks.ompt_callback(ompt_callback_mutex_acquire)(
             ompt_mutex_nest_lock,
             omp_lock_hint_none,
-            0, //TODO for intel: specify impl
+            ompt_mutex_impl_unknown,
             (ompt_wait_id_t) lck,
             OMPT_GET_RETURN_ADDRESS(0));
     }

--- a/runtime/src/kmp_csupport.cpp
+++ b/runtime/src/kmp_csupport.cpp
@@ -532,7 +532,7 @@ __kmpc_end_serialized_parallel(ident_t *loc, kmp_int32 global_tid)
 
 #if OMPT_SUPPORT
     OMPT_STORE_KMP_RETURN_ADDRESS(global_tid);
-    if (ompt_enabled && this_thr->th.ompt_thread_info.state != ompt_state_overhead) {
+    if (ompt_enabled && this_thr->th.ompt_thread_info.state != omp_state_overhead) {
         this_thr->th.th_current_task->ompt_task_info.frame.exit_runtime_frame = NULL;
         if (ompt_callbacks.ompt_callback(ompt_callback_implicit_task)) {
             ompt_callbacks.ompt_callback(ompt_callback_implicit_task)(
@@ -555,7 +555,7 @@ __kmpc_end_serialized_parallel(ident_t *loc, kmp_int32 global_tid)
                 OMPT_LOAD_RETURN_ADDRESS(global_tid));
         }
         __ompt_lw_taskteam_unlink(this_thr);
-        this_thr->th.ompt_thread_info.state = ompt_state_overhead;
+        this_thr->th.ompt_thread_info.state = omp_state_overhead;
     }
 #endif
 
@@ -627,7 +627,7 @@ __kmpc_end_serialized_parallel(ident_t *loc, kmp_int32 global_tid)
 #if OMPT_SUPPORT
     if (ompt_enabled )
         this_thr->th.ompt_thread_info.state = ((this_thr -> th.th_team_serialized) ?
-          ompt_state_work_serial : ompt_state_work_parallel);
+          omp_state_work_serial : omp_state_work_parallel);
 #endif
 }
 
@@ -891,7 +891,7 @@ __kmpc_ordered( ident_t * loc, kmp_int32 gtid )
         lck = (ompt_wait_id_t) &team->t.t_ordered.dt.t_value;
         /* OMPT state update */
         th->th.ompt_thread_info.wait_id = lck;
-        th->th.ompt_thread_info.state = ompt_state_wait_ordered;
+        th->th.ompt_thread_info.state = omp_state_wait_ordered;
 
         /* OMPT event callback */
         if (ompt_callbacks.ompt_callback(ompt_callback_mutex_acquire)) {
@@ -913,7 +913,7 @@ __kmpc_ordered( ident_t * loc, kmp_int32 gtid )
 #if OMPT_SUPPORT && OMPT_OPTIONAL
     if (ompt_enabled) {
         /* OMPT state update */
-        th->th.ompt_thread_info.state = ompt_state_work_parallel;
+        th->th.ompt_thread_info.state = omp_state_work_parallel;
         th->th.ompt_thread_info.wait_id = 0;
 
         /* OMPT event callback */
@@ -1173,7 +1173,7 @@ __kmpc_critical( ident_t * loc, kmp_int32 global_tid, kmp_critical_name * crit )
     KMP_COUNT_BLOCK(OMP_CRITICAL);
     KMP_TIME_PARTITIONED_BLOCK(OMP_critical_wait);        /* Time spent waiting to enter the critical section */
 #if OMPT_SUPPORT && OMPT_OPTIONAL
-    ompt_state_t prev_state = ompt_state_undefined;
+    omp_state_t prev_state = omp_state_undefined;
     ompt_thread_info_t ti;
 #endif
     kmp_user_lock_p lck;
@@ -1216,7 +1216,7 @@ __kmpc_critical( ident_t * loc, kmp_int32 global_tid, kmp_critical_name * crit )
         /* OMPT state update */
         prev_state = ti.state;
         ti.wait_id = (ompt_wait_id_t) lck;
-        ti.state = ompt_state_wait_critical;
+        ti.state = omp_state_wait_critical;
 
         /* OMPT event callback */
         if (ompt_callbacks.ompt_callback(ompt_callback_mutex_acquire)) {
@@ -1321,7 +1321,7 @@ __kmpc_critical_with_hint( ident_t * loc, kmp_int32 global_tid, kmp_critical_nam
     KMP_COUNT_BLOCK(OMP_CRITICAL);
     kmp_user_lock_p lck;
 #if OMPT_SUPPORT && OMPT_OPTIONAL
-    ompt_state_t prev_state = ompt_state_undefined;
+    omp_state_t prev_state = omp_state_undefined;
     ompt_thread_info_t ti;
 #endif
 
@@ -1353,7 +1353,7 @@ __kmpc_critical_with_hint( ident_t * loc, kmp_int32 global_tid, kmp_critical_nam
             /* OMPT state update */
             prev_state = ti.state;
             ti.wait_id = (ompt_wait_id_t) lck;
-            ti.state = ompt_state_wait_critical;
+            ti.state = omp_state_wait_critical;
 
             /* OMPT event callback */
             if (ompt_callbacks.ompt_callback(ompt_callback_mutex_acquire)) {
@@ -1393,7 +1393,7 @@ __kmpc_critical_with_hint( ident_t * loc, kmp_int32 global_tid, kmp_critical_nam
             /* OMPT state update */
             prev_state = ti.state;
             ti.wait_id = (ompt_wait_id_t) lck;
-            ti.state = ompt_state_wait_critical;
+            ti.state = omp_state_wait_critical;
 
             /* OMPT event callback */
             if (ompt_callbacks.ompt_callback(ompt_callback_mutex_acquire)) {
@@ -1711,7 +1711,7 @@ __kmpc_single(ident_t *loc, kmp_int32 global_tid)
                     1,
                     OMPT_GET_RETURN_ADDRESS(0));
             }
-//            this_thr->th.ompt_thread_info.state = ompt_state_work_parallel;
+//            this_thr->th.ompt_thread_info.state = omp_state_work_parallel;
         }
     }
 #endif

--- a/runtime/src/kmp_csupport.cpp
+++ b/runtime/src/kmp_csupport.cpp
@@ -2298,7 +2298,7 @@ __kmpc_init_nest_lock( ident_t * loc, kmp_int32 gtid, void ** user_lock ) {
     if (ompt_enabled &&
         ompt_callbacks.ompt_callback(ompt_callback_lock_init)) {
         ompt_callbacks.ompt_callback(ompt_callback_lock_init)(
-            ompt_mutex_lock,
+            ompt_mutex_nest_lock,
             omp_lock_hint_none,
             __ompt_get_mutex_impl_type(user_lock),
             (ompt_wait_id_t)user_lock,

--- a/runtime/src/kmp_gsupport.cpp
+++ b/runtime/src/kmp_gsupport.cpp
@@ -188,7 +188,7 @@ xexpand(KMP_API_NAME_GOMP_SINGLE_START)(void)
                     1,
                     OMPT_GET_RETURN_ADDRESS(0));
             }
-//            this_thr->th.ompt_thread_info.state = ompt_state_work_parallel;
+//            this_thr->th.ompt_thread_info.state = omp_state_work_parallel;
         }
     }
 #endif
@@ -344,7 +344,7 @@ __kmp_GOMP_microtask_wrapper(int *gtid, int *npr, void (*task)(void *),
 #if OMPT_SUPPORT
     kmp_info_t *thr;
     ompt_frame_t *ompt_frame;
-    ompt_state_t enclosing_state;
+    omp_state_t enclosing_state;
 
     if (ompt_enabled) {
         // get pointer to thread data structure
@@ -352,7 +352,7 @@ __kmp_GOMP_microtask_wrapper(int *gtid, int *npr, void (*task)(void *),
 
         // save enclosing task state; set current state for task
         enclosing_state = thr->th.ompt_thread_info.state;
-        thr->th.ompt_thread_info.state = ompt_state_work_parallel;
+        thr->th.ompt_thread_info.state = omp_state_work_parallel;
 
         // set task frame
         __ompt_get_task_info_internal(0, NULL, NULL, &ompt_frame, NULL, NULL);
@@ -396,13 +396,13 @@ __kmp_GOMP_parallel_microtask_wrapper(int *gtid, int *npr,
 #if OMPT_SUPPORT
     kmp_info_t *thr;
     ompt_frame_t *ompt_frame;
-    ompt_state_t enclosing_state;
+    omp_state_t enclosing_state;
 
     if (ompt_enabled) {
         thr = __kmp_threads[*gtid];
         // save enclosing task state; set current state for task
         enclosing_state = thr->th.ompt_thread_info.state;
-        thr->th.ompt_thread_info.state = ompt_state_work_parallel;
+        thr->th.ompt_thread_info.state = omp_state_work_parallel;
 
         // set task frame
         __ompt_get_task_info_internal(0, NULL, NULL, &ompt_frame, NULL, NULL);
@@ -475,7 +475,7 @@ __kmp_GOMP_fork_call(ident_t *loc, int gtid, void (*unwrapped_task)(void *), mic
                 ompt_team_size,
                 __kmp_tid_from_gtid(gtid));
         }
-        thr->th.ompt_thread_info.state = ompt_state_work_parallel;
+        thr->th.ompt_thread_info.state = omp_state_work_parallel;
     }
 #endif
 }
@@ -600,7 +600,7 @@ xexpand(KMP_API_NAME_GOMP_PARALLEL_END)(void)
                 OMPT_CUR_TASK_DATA(thr),
                 ompt_team_size,
                 __kmp_tid_from_gtid(gtid));
-            thr->th.ompt_thread_info.state = ompt_state_overhead;
+            thr->th.ompt_thread_info.state = omp_state_overhead;
         }
 #endif
 
@@ -625,7 +625,7 @@ xexpand(KMP_API_NAME_GOMP_PARALLEL_END)(void)
 
             thr->th.ompt_thread_info.state =
                 (((thr->th.th_team)->t.t_serialized) ?
-                ompt_state_work_serial : ompt_state_work_parallel);
+                omp_state_work_serial : omp_state_work_parallel);
         }
 #endif
     }
@@ -1071,7 +1071,7 @@ xexpand(KMP_API_NAME_GOMP_TASK)(void (*func)(void *), void *data, void (*copy_fu
             taskdata = KMP_TASK_TO_TASKDATA(task);
             oldInfo = thread->th.ompt_thread_info;
             thread->th.ompt_thread_info.wait_id = 0;
-            thread->th.ompt_thread_info.state = ompt_state_work_parallel;
+            thread->th.ompt_thread_info.state = omp_state_work_parallel;
             taskdata->ompt_task_info.frame.exit_runtime_frame =
                 OMPT_GET_FRAME_ADDRESS(0);
         }

--- a/runtime/src/kmp_lock.cpp
+++ b/runtime/src/kmp_lock.cpp
@@ -1241,7 +1241,7 @@ __kmp_acquire_queuing_lock_timed_template( kmp_queuing_lock_t *lck,
     kmp_int32 need_mf = 1;
 
 #if OMPT_SUPPORT
-    ompt_state_t prev_state = ompt_state_undefined;
+    omp_state_t prev_state = omp_state_undefined;
 #endif
 
     KA_TRACE( 1000, ("__kmp_acquire_queuing_lock: lck:%p, T#%d entering\n", lck, gtid ));
@@ -1349,7 +1349,7 @@ __kmp_acquire_queuing_lock_timed_template( kmp_queuing_lock_t *lck,
 #endif
 
 #if OMPT_SUPPORT
-                    if (ompt_enabled && prev_state != ompt_state_undefined) {
+                    if (ompt_enabled && prev_state != omp_state_undefined) {
                         /* change the state before clearing wait_id */
                         this_thr->th.ompt_thread_info.state = prev_state;
                         this_thr->th.ompt_thread_info.wait_id = 0;
@@ -1365,11 +1365,11 @@ __kmp_acquire_queuing_lock_timed_template( kmp_queuing_lock_t *lck,
         }
 
 #if OMPT_SUPPORT
-        if (ompt_enabled && prev_state == ompt_state_undefined) {
+        if (ompt_enabled && prev_state == omp_state_undefined) {
             /* this thread will spin; set wait_id before entering wait state */
             prev_state = this_thr->th.ompt_thread_info.state;
             this_thr->th.ompt_thread_info.wait_id = (uint64_t) lck;
-            this_thr->th.ompt_thread_info.state = ompt_state_wait_lock;
+            this_thr->th.ompt_thread_info.state = omp_state_wait_lock;
         }
 #endif
 

--- a/runtime/src/kmp_runtime.cpp
+++ b/runtime/src/kmp_runtime.cpp
@@ -1223,7 +1223,7 @@ __kmp_serialized_parallel(ident_t *loc, kmp_int32 global_tid)
     ompt_parallel_data_t ompt_parallel_data;
     ompt_parallel_data.ptr = NULL;
     ompt_task_data_t *implicit_task_data;
-    if (ompt_enabled && this_thr->th.ompt_thread_info.state != ompt_state_overhead) {
+    if (ompt_enabled && this_thr->th.ompt_thread_info.state != omp_state_overhead) {
 
         ompt_task_info_t *parent_task_info;
 //        if (serial_team->t.t_level > 1)
@@ -1391,7 +1391,7 @@ __kmp_serialized_parallel(ident_t *loc, kmp_int32 global_tid)
     if ( __kmp_env_consistency_check )
         __kmp_push_parallel( global_tid, NULL );
 #if OMPT_SUPPORT
-    if (ompt_enabled && this_thr->th.ompt_thread_info.state != ompt_state_overhead) {
+    if (ompt_enabled && this_thr->th.ompt_thread_info.state != omp_state_overhead) {
         OMPT_CUR_TASK_INFO(this_thr)->frame.exit_runtime_frame=OMPT_GET_FRAME_ADDRESS(1);
         void *dummy;
         void **exit_runtime_p;
@@ -1417,7 +1417,7 @@ __kmp_serialized_parallel(ident_t *loc, kmp_int32 global_tid)
         }
 
         /* OMPT state */
-        this_thr->th.ompt_thread_info.state = ompt_state_work_parallel;
+        this_thr->th.ompt_thread_info.state = omp_state_work_parallel;
         OMPT_CUR_TASK_INFO(this_thr)->frame.exit_runtime_frame = OMPT_GET_FRAME_ADDRESS(1);
     }
 #endif
@@ -1536,7 +1536,7 @@ __kmp_fork_call(
                 OMPT_INVOKER(call_context),
                 return_address);
         }
-        master_th->th.ompt_thread_info.state = ompt_state_overhead;
+        master_th->th.ompt_thread_info.state = omp_state_overhead;
     }
 #endif
 
@@ -1594,7 +1594,7 @@ __kmp_fork_call(
                 }
 
                 /* OMPT state */
-                master_th->th.ompt_thread_info.state = ompt_state_work_parallel;
+                master_th->th.ompt_thread_info.state = omp_state_work_parallel;
             } else {
                 exit_runtime_p = &dummy;
             }
@@ -1631,7 +1631,7 @@ __kmp_fork_call(
                         OMPT_INVOKER(call_context),
                         return_address);
                 }
-                master_th->th.ompt_thread_info.state = ompt_state_overhead;
+                master_th->th.ompt_thread_info.state = omp_state_overhead;
             }
 #endif
             return TRUE;
@@ -1795,7 +1795,7 @@ __kmp_fork_call(
                     }
 
                     /* OMPT state */
-                    master_th->th.ompt_thread_info.state = ompt_state_work_parallel;
+                    master_th->th.ompt_thread_info.state = omp_state_work_parallel;
                 } else {
                     exit_runtime_p = &dummy;
                 }
@@ -1830,7 +1830,7 @@ __kmp_fork_call(
                             OMPT_INVOKER(call_context),
                             return_address);
                     }
-                    master_th->th.ompt_thread_info.state = ompt_state_overhead;
+                    master_th->th.ompt_thread_info.state = omp_state_overhead;
                 }
 #endif
             } else if ( microtask == (microtask_t)__kmp_teams_master ) {
@@ -1903,7 +1903,7 @@ __kmp_fork_call(
 
 
                     /* OMPT state */
-                    master_th->th.ompt_thread_info.state = ompt_state_work_parallel;
+                    master_th->th.ompt_thread_info.state = omp_state_work_parallel;
                 } else {
                     exit_runtime_p = &dummy;
                 }
@@ -1938,7 +1938,7 @@ __kmp_fork_call(
                             OMPT_INVOKER(call_context),
                             return_address);
                     }
-                    master_th->th.ompt_thread_info.state = ompt_state_overhead;
+                    master_th->th.ompt_thread_info.state = omp_state_overhead;
                 }
 #endif
 #if OMP_40_ENABLED
@@ -2191,7 +2191,7 @@ __kmp_fork_call(
     __kmp_setup_icv_copy( team, nthreads, &master_th->th.th_current_task->td_icvs, loc );
 
 #if OMPT_SUPPORT
-    master_th->th.ompt_thread_info.state = ompt_state_work_parallel;
+    master_th->th.ompt_thread_info.state = omp_state_work_parallel;
 #endif
 
     __kmp_release_bootstrap_lock( &__kmp_forkjoin_lock );
@@ -2269,7 +2269,7 @@ __kmp_fork_call(
 
 #if OMPT_SUPPORT
     if (ompt_enabled) {
-        master_th->th.ompt_thread_info.state = ompt_state_overhead;
+        master_th->th.ompt_thread_info.state = omp_state_overhead;
     }
 #endif
 
@@ -2284,7 +2284,7 @@ __kmp_join_restore_state(
 {
     // restore state outside the region
     thread->th.ompt_thread_info.state = ((team->t.t_serialized) ?
-        ompt_state_work_serial : ompt_state_work_parallel);
+        omp_state_work_serial : omp_state_work_parallel);
 }
 
 static inline void
@@ -2338,7 +2338,7 @@ __kmp_join_call(ident_t *loc, int gtid
 
 #if OMPT_SUPPORT
     if (ompt_enabled) {
-        master_th->th.ompt_thread_info.state = ompt_state_overhead;
+        master_th->th.ompt_thread_info.state = omp_state_overhead;
     }
 #endif
 
@@ -3863,7 +3863,7 @@ __kmp_register_root( int initial_thread )
 
         ompt_thread_t *root_thread = ompt_get_thread();
 
-        ompt_set_thread_state(root_thread, ompt_state_overhead);
+        ompt_set_thread_state(root_thread, omp_state_overhead);
 
         if (ompt_callbacks.ompt_callback(ompt_callback_thread_begin)) {
             ompt_callbacks.ompt_callback(ompt_callback_thread_begin)(
@@ -3881,7 +3881,7 @@ __kmp_register_root( int initial_thread )
                 OMPT_GET_RETURN_ADDRESS(0));
         }
 
-        ompt_set_thread_state(root_thread, ompt_state_work_serial);
+        ompt_set_thread_state(root_thread, omp_state_work_serial);
     }
 #endif
 
@@ -4020,7 +4020,7 @@ __kmp_unregister_root_current_thread( int gtid )
    if ( task_team != NULL && task_team->tt.tt_found_proxy_tasks ) {
 #if OMPT_SUPPORT
         // the runtime is shutting down so we won't report any events
-        thread->th.ompt_thread_info.state = ompt_state_undefined;
+        thread->th.ompt_thread_info.state = omp_state_undefined;
 #endif
         __kmp_task_team_wait(thread, team USE_ITT_BUILD_ARG(NULL));
    }
@@ -5573,7 +5573,7 @@ __kmp_launch_thread( kmp_info_t *this_thr )
         thread_data = &(this_thr->th.ompt_thread_info.thread_data);
         thread_data->ptr = NULL;
 
-        this_thr->th.ompt_thread_info.state = ompt_state_overhead;
+        this_thr->th.ompt_thread_info.state = omp_state_overhead;
         this_thr->th.ompt_thread_info.wait_id = 0;
         this_thr->th.ompt_thread_info.idle_frame = OMPT_GET_FRAME_ADDRESS(0);
         if (ompt_callbacks.ompt_callback(ompt_callback_thread_begin)) {
@@ -5585,7 +5585,7 @@ __kmp_launch_thread( kmp_info_t *this_thr )
 
 #if OMPT_SUPPORT
         if (ompt_enabled) {
-            this_thr->th.ompt_thread_info.state = ompt_state_idle;
+            this_thr->th.ompt_thread_info.state = omp_state_idle;
         }
 #endif
     /* This is the place where threads wait for work */
@@ -5602,7 +5602,7 @@ __kmp_launch_thread( kmp_info_t *this_thr )
 
 #if OMPT_SUPPORT
         if (ompt_enabled) {
-            this_thr->th.ompt_thread_info.state = ompt_state_overhead;
+            this_thr->th.ompt_thread_info.state = omp_state_overhead;
         }
 #endif
 
@@ -5630,7 +5630,7 @@ __kmp_launch_thread( kmp_info_t *this_thr )
 
 #if OMPT_SUPPORT
                 if (ompt_enabled) {
-                    this_thr->th.ompt_thread_info.state = ompt_state_work_parallel;
+                    this_thr->th.ompt_thread_info.state = omp_state_work_parallel;
                     // Initialize OMPT task id for implicit task.
 //                    int tid = __kmp_tid_from_gtid(gtid);
 //                    task_info->task_data.value = __ompt_task_id_new(tid);
@@ -5653,7 +5653,7 @@ __kmp_launch_thread( kmp_info_t *this_thr )
                 /* no frame set while outside task */
                 __ompt_get_task_info_object(0)->frame.exit_runtime_frame = NULL;
 
-                this_thr->th.ompt_thread_info.state = ompt_state_overhead;
+                this_thr->th.ompt_thread_info.state = omp_state_overhead;
                 this_thr->th.ompt_thread_info.parallel_data = (*pteam)->t.ompt_team_info.parallel_data;
                 this_thr->th.ompt_thread_info.task_data = *OMPT_CUR_TASK_DATA(this_thr);
             }
@@ -7218,10 +7218,10 @@ __kmp_internal_join( ident_t *id, int gtid, kmp_team_t *team )
     __kmp_join_barrier( gtid );  /* wait for everyone */
 #if OMPT_SUPPORT
     int ds_tid = this_thr->th.th_info.ds.ds_tid;
-    if (this_thr->th.ompt_thread_info.state == ompt_state_wait_barrier_implicit) {
+    if (this_thr->th.ompt_thread_info.state == omp_state_wait_barrier_implicit) {
         ompt_task_data_t* tId = &(this_thr->th.th_current_task->ompt_task_info.task_data);
         ompt_parallel_data_t* pId = &(this_thr->th.th_team->t.ompt_team_info.parallel_data);
-        this_thr->th.ompt_thread_info.state = ompt_state_overhead;
+        this_thr->th.ompt_thread_info.state = omp_state_overhead;
 #if OMPT_OPTIONAL
         if (ompt_callbacks.ompt_callback(ompt_callback_sync_region_wait)) {
             ompt_callbacks.ompt_callback(ompt_callback_sync_region_wait)(
@@ -7249,7 +7249,7 @@ __kmp_internal_join( ident_t *id, int gtid, kmp_team_t *team )
                 ds_tid);
         }
         // return to idle state
-        this_thr->th.ompt_thread_info.state = ompt_state_overhead;
+        this_thr->th.ompt_thread_info.state = omp_state_overhead;
     }
 #endif
 

--- a/runtime/src/kmp_tasking.cpp
+++ b/runtime/src/kmp_tasking.cpp
@@ -1278,7 +1278,7 @@ __kmp_invoke_task( kmp_int32 gtid, kmp_task_t *task, kmp_taskdata_t * current_ta
         thread = __kmp_threads[ gtid ];
         oldInfo = thread->th.ompt_thread_info;
         thread->th.ompt_thread_info.wait_id = 0;
-        thread->th.ompt_thread_info.state = ompt_state_work_parallel;
+        thread->th.ompt_thread_info.state = omp_state_work_parallel;
         taskdata->ompt_task_info.frame.exit_runtime_frame = OMPT_GET_FRAME_ADDRESS(0);
     }
 #endif

--- a/runtime/src/ompt-general.cpp
+++ b/runtime/src/ompt-general.cpp
@@ -46,6 +46,10 @@ typedef struct {
     omp_state_t  state_id;
 } omp_state_info_t;
 
+typedef struct {
+    const char *name;
+    ompt_mutex_impl_t id;
+} ompt_mutex_impl_info_t;
 
 enum tool_setting_e {
     omp_tool_error,
@@ -74,6 +78,12 @@ omp_state_info_t omp_state_info[] = {
 #define omp_state_macro(state, code) { # state, state },
     FOREACH_OMP_STATE(omp_state_macro)
 #undef omp_state_macro
+};
+
+ompt_mutex_impl_info_t ompt_mutex_impl_info[] = {
+#define ompt_mutex_impl_macro(name, id) { #name, name },
+    FOREACH_OMPT_MUTEX_IMPL(ompt_mutex_impl_macro)
+#undef ompt_mutex_impl_macro
 };
 
 ompt_callbacks_internal_t ompt_callbacks;
@@ -356,6 +366,20 @@ OMPT_API_ROUTINE int ompt_enumerate_states(int current_state, int *next_state,
     return 0;
 }
 
+OMPT_API_ROUTINE int ompt_enumerate_mutex_impls(int current_impl, int *next_impl,
+                                                const char **next_impl_name)
+{
+    const static int len = sizeof(ompt_mutex_impl_info) / sizeof(ompt_mutex_impl_info_t);
+    int i = 0;
+    for (i = 0; i < len - 1; i++) {
+        if (ompt_mutex_impl_info[i].id != current_impl)
+            continue;
+        *next_impl = ompt_mutex_impl_info[i+1].id;
+        *next_impl_name = ompt_mutex_impl_info[i+1].name;
+        return 1;
+    }
+    return 0;
+}
 
 
 /*****************************************************************************

--- a/runtime/src/ompt-general.cpp
+++ b/runtime/src/ompt-general.cpp
@@ -43,8 +43,8 @@
 
 typedef struct {
     const char *state_name;
-    ompt_state_t  state_id;
-} ompt_state_info_t;
+    omp_state_t  state_id;
+} omp_state_info_t;
 
 
 enum tool_setting_e {
@@ -70,10 +70,10 @@ typedef void (*ompt_finalize_t) (
 
 int ompt_enabled = 0;
 
-ompt_state_info_t ompt_state_info[] = {
-#define ompt_state_macro(state, code) { # state, state },
-    FOREACH_OMPT_STATE(ompt_state_macro)
-#undef ompt_state_macro
+omp_state_info_t omp_state_info[] = {
+#define omp_state_macro(state, code) { # state, state },
+    FOREACH_OMP_STATE(omp_state_macro)
+#undef omp_state_macro
 };
 
 ompt_callbacks_internal_t ompt_callbacks;
@@ -299,7 +299,7 @@ void ompt_post_init()
 
         ompt_thread_t *root_thread = ompt_get_thread();
 
-        ompt_set_thread_state(root_thread, ompt_state_overhead);
+        ompt_set_thread_state(root_thread, omp_state_overhead);
 
         if (ompt_callbacks.ompt_callback(ompt_callback_thread_begin)) {
             ompt_callbacks.ompt_callback(ompt_callback_thread_begin)(
@@ -317,7 +317,7 @@ void ompt_post_init()
                 OMPT_GET_RETURN_ADDRESS(0));
         }
 
-        ompt_set_thread_state(root_thread, ompt_state_work_serial);
+        ompt_set_thread_state(root_thread, omp_state_work_serial);
     }
 }
 
@@ -342,13 +342,13 @@ void ompt_fini()
 OMPT_API_ROUTINE int ompt_enumerate_states(int current_state, int *next_state,
                                           const char **next_state_name)
 {
-    const static int len = sizeof(ompt_state_info) / sizeof(ompt_state_info_t);
+    const static int len = sizeof(omp_state_info) / sizeof(omp_state_info_t);
     int i = 0;
 
     for (i = 0; i < len - 1; i++) {
-        if (ompt_state_info[i].state_id == current_state) {
-            *next_state = ompt_state_info[i+1].state_id;
-            *next_state_name = ompt_state_info[i+1].state_name;
+        if (omp_state_info[i].state_id == current_state) {
+            *next_state = omp_state_info[i+1].state_id;
+            *next_state_name = omp_state_info[i+1].state_name;
             return 1;
         }
     }
@@ -416,12 +416,12 @@ OMPT_API_ROUTINE int ompt_get_parallel_info(int ancestor_level, ompt_data_t **pa
     return __ompt_get_parallel_info_internal(ancestor_level, parallel_data, team_size);
 }
 
-OMPT_API_ROUTINE ompt_state_t ompt_get_state(ompt_wait_id_t *wait_id)
+OMPT_API_ROUTINE omp_state_t ompt_get_state(ompt_wait_id_t *wait_id)
 {
-    ompt_state_t thread_state = __ompt_get_state_internal(wait_id);
+    omp_state_t thread_state = __ompt_get_state_internal(wait_id);
 
-    if (thread_state == ompt_state_undefined) {
-        thread_state = ompt_state_work_serial;
+    if (thread_state == omp_state_undefined) {
+        thread_state = omp_state_work_serial;
     }
 
     return thread_state;

--- a/runtime/src/ompt-internal.h
+++ b/runtime/src/ompt-internal.h
@@ -66,7 +66,7 @@ typedef struct {
     ompt_task_data_t      task_data; /* stored here from implicit barrier-begin until implicit-task-end */
     void                  *kmp_return_address; /* stored here on entry of runtime */
     void                  *gomp_return_address; /* stored here on entry of runtime */
-    ompt_state_t          state;
+    omp_state_t           state;
     ompt_wait_id_t        wait_id;
     int                   ompt_task_yielded;
     void                  *idle_frame;

--- a/runtime/src/ompt-specific.cpp
+++ b/runtime/src/ompt-specific.cpp
@@ -250,7 +250,7 @@ __ompt_thread_assign_wait_id(void *variable)
     ti->th.ompt_thread_info.wait_id = (ompt_wait_id_t) variable;
 }
 
-ompt_state_t
+omp_state_t
 __ompt_get_state_internal(ompt_wait_id_t *ompt_wait_id)
 {
     kmp_info_t *ti = ompt_get_thread();
@@ -260,7 +260,7 @@ __ompt_get_state_internal(ompt_wait_id_t *ompt_wait_id)
             *ompt_wait_id = ti->th.ompt_thread_info.wait_id;
         return ti->th.ompt_thread_info.state;
     }
-    return ompt_state_undefined;
+    return omp_state_undefined;
 }
 
 //----------------------------------------------------------

--- a/runtime/src/ompt-specific.h
+++ b/runtime/src/ompt-specific.h
@@ -100,7 +100,7 @@ ompt_get_thread()
 
 
 inline void
-ompt_set_thread_state(ompt_thread_t *thread, ompt_state_t state)
+ompt_set_thread_state(ompt_thread_t *thread, omp_state_t state)
 {
     thread->th.ompt_thread_info.state = state;
 }

--- a/runtime/test/ompt/callback.h
+++ b/runtime/test/ompt/callback.h
@@ -52,6 +52,7 @@ static ompt_get_place_proc_ids_t ompt_get_place_proc_ids;
 static ompt_get_place_num_t ompt_get_place_num;
 static ompt_get_partition_place_nums_t ompt_get_partition_place_nums;
 static ompt_get_proc_id_t ompt_get_proc_id;
+static ompt_enumerate_states_t ompt_enumerate_states;
 
 static void print_ids(int level)
 {
@@ -626,6 +627,7 @@ int ompt_initialize(
   ompt_get_place_num = (ompt_get_place_num_t) lookup("ompt_get_place_num");
   ompt_get_partition_place_nums = (ompt_get_partition_place_nums_t) lookup("ompt_get_partition_place_nums");
   ompt_get_proc_id = (ompt_get_proc_id_t) lookup("ompt_get_proc_id");
+  ompt_enumerate_states = (ompt_enumerate_states_t) lookup("ompt_enumerate_states");
 
   register_callback(ompt_callback_mutex_acquire);
   register_callback_t(ompt_callback_mutex_acquired, ompt_callback_mutex_t);

--- a/runtime/test/ompt/callback.h
+++ b/runtime/test/ompt/callback.h
@@ -53,6 +53,7 @@ static ompt_get_place_num_t ompt_get_place_num;
 static ompt_get_partition_place_nums_t ompt_get_partition_place_nums;
 static ompt_get_proc_id_t ompt_get_proc_id;
 static ompt_enumerate_states_t ompt_enumerate_states;
+static ompt_enumerate_mutex_impls_t ompt_enumerate_mutex_impls;
 
 static void print_ids(int level)
 {
@@ -628,6 +629,7 @@ int ompt_initialize(
   ompt_get_partition_place_nums = (ompt_get_partition_place_nums_t) lookup("ompt_get_partition_place_nums");
   ompt_get_proc_id = (ompt_get_proc_id_t) lookup("ompt_get_proc_id");
   ompt_enumerate_states = (ompt_enumerate_states_t) lookup("ompt_enumerate_states");
+  ompt_enumerate_mutex_impls = (ompt_enumerate_mutex_impls_t) lookup("ompt_enumerate_mutex_impls");
 
   register_callback(ompt_callback_mutex_acquire);
   register_callback_t(ompt_callback_mutex_acquired, ompt_callback_mutex_t);


### PR DESCRIPTION
This change set partially addresses Issue #7 and #8.
For #7, it is mostly name changes, and I didn't touch any other things.
For #8, I wasn't sure what would be an acceptable categorization method, so just think of it as a proposal. Only three implementation types are defined - spin, queuing, speculative.
* speculative - employs HW/SW support for speculative execution
* queuing - enforces fairness
* spin - all other spin-based ones