### PR TITLE
Declare omp_control_tool in Fortran header (Issue #21)

### DIFF
--- a/runtime/src/include/50/omp_lib.f.var
+++ b/runtime/src/include/50/omp_lib.f.var
@@ -32,6 +32,8 @@
         integer, parameter :: kmp_affinity_mask_kind = int_ptr_kind()
         integer, parameter :: kmp_cancel_kind        = omp_integer_kind
         integer, parameter :: omp_lock_hint_kind     = omp_integer_kind
+        integer, parameter :: omp_control_tool_kind  = omp_integer_kind
+        integer, parameter :: omp_control_tool_result_kind = omp_integer_kind
 
       end module omp_lib_kinds
 
@@ -518,6 +520,13 @@
             integer (kind=omp_lock_hint_kind) hint
           end subroutine omp_init_nest_lock_with_hint
 
+          function omp_control_tool(command, modifier)
+            use omp_lib_kinds
+            integer (kind=omp_integer_kind) omp_control_tool
+            integer (kind=omp_control_tool_kind) command
+            integer (kind=omp_control_tool_kind) modifier
+          end function omp_control_tool
+
         end interface
 
 !dec$ if defined(_WIN32)
@@ -607,6 +616,8 @@
 
 !dec$ attributes alias:'KMP_GET_CANCELLATION_STATUS' :: kmp_get_cancellation_status
 
+!dec$ attributes alias:'OMP_CONTROL_TOOL' :: omp_control_tool
+
 !dec$   else
 
 !***
@@ -686,6 +697,8 @@
 !dec$ attributes alias:'_KMP_SET_WARNINGS_OFF'::kmp_set_warnings_off
 
 !dec$ attributes alias:'_KMP_GET_CANCELLATION_STATUS' :: kmp_get_cancellation_status
+
+!dec$ attributes alias:'_OMP_CONTROL_TOOL' :: omp_control_tool
 
 !dec$   endif
 !dec$ endif
@@ -769,6 +782,8 @@
 !dec$ attributes alias:'kmp_set_warnings_off_'::kmp_set_warnings_off
 !dec$ attributes alias:'kmp_get_cancellation_status_'::kmp_get_cancellation_status
 
+!dec$ attributes alias:'omp_control_tool_'::omp_control_tool
+
 !dec$ endif
 
 !dec$ if defined(__APPLE__)
@@ -848,6 +863,8 @@
 !dec$ attributes alias:'_kmp_set_warnings_off_'::kmp_set_warnings_off
 
 !dec$ attributes alias:'_kmp_get_cancellation_status_'::kmp_get_cancellation_status
+
+!dec$ attributes alias:'_omp_control_tool_'::omp_control_tool
 
 !dec$ endif
 

--- a/runtime/src/include/50/omp_lib.f90.var
+++ b/runtime/src/include/50/omp_lib.f90.var
@@ -28,6 +28,8 @@
         integer, parameter :: kmp_affinity_mask_kind = c_intptr_t
         integer, parameter :: kmp_cancel_kind        = omp_integer_kind
         integer, parameter :: omp_lock_hint_kind     = omp_integer_kind
+        integer, parameter :: omp_control_tool_kind  = omp_integer_kind
+        integer, parameter :: omp_control_tool_result_kind = omp_integer_kind
 
       end module omp_lib_kinds
 
@@ -67,6 +69,16 @@
         integer (kind=omp_lock_hint_kind), parameter :: kmp_lock_hint_hle            = 65536
         integer (kind=omp_lock_hint_kind), parameter :: kmp_lock_hint_rtm            = 131072
         integer (kind=omp_lock_hint_kind), parameter :: kmp_lock_hint_adaptive       = 262144
+
+        integer (kind=omp_control_tool_kind), parameter :: omp_control_tool_start = 1
+        integer (kind=omp_control_tool_kind), parameter :: omp_control_tool_pause = 2
+        integer (kind=omp_control_tool_kind), parameter :: omp_control_tool_flush = 3
+        integer (kind=omp_control_tool_kind), parameter :: omp_control_tool_end = 4
+
+        integer (kind=omp_control_tool_result_kind), parameter :: omp_control_tool_notool = -2
+        integer (kind=omp_control_tool_result_kind), parameter :: omp_control_tool_nocallback = -1
+        integer (kind=omp_control_tool_result_kind), parameter :: omp_control_tool_success = 0
+        integer (kind=omp_control_tool_result_kind), parameter :: omp_control_tool_ignored = 1
 
         interface
 
@@ -518,6 +530,13 @@
             integer (kind=omp_nest_lock_kind) nvar
             integer (kind=omp_lock_hint_kind), value :: hint
           end subroutine omp_init_nest_lock_with_hint
+
+          function omp_control_tool(command, modifier) bind(c)
+            use omp_lib_kinds
+            integer (kind=omp_integer_kind) omp_control_tool
+            integer (kind=omp_control_tool_kind), value :: command
+            integer (kind=omp_control_tool_kind), value :: modifier
+          end function omp_control_tool
 
         end interface
 

--- a/runtime/src/include/50/omp_lib.h.var
+++ b/runtime/src/include/50/omp_lib.h.var
@@ -29,6 +29,8 @@
       integer, parameter :: kmp_size_t_kind        = int_ptr_kind()
       integer, parameter :: kmp_affinity_mask_kind = int_ptr_kind()
       integer, parameter :: omp_lock_hint_kind     = omp_integer_kind
+      integer, parameter :: omp_control_tool_kind  = omp_integer_kind
+      integer, parameter :: omp_control_tool_result_kind = omp_integer_kind
 
       integer (kind=omp_integer_kind), parameter :: openmp_version    = @LIBOMP_OMP_YEAR_MONTH@
       integer (kind=omp_integer_kind), parameter :: kmp_version_major = @LIBOMP_VERSION_MAJOR@
@@ -56,6 +58,16 @@
       integer (kind=omp_lock_hint_kind), parameter :: kmp_lock_hint_hle            = 65536
       integer (kind=omp_lock_hint_kind), parameter :: kmp_lock_hint_rtm            = 131072
       integer (kind=omp_lock_hint_kind), parameter :: kmp_lock_hint_adaptive       = 262144
+
+      integer (kind=omp_control_tool_kind), parameter :: omp_control_tool_start = 1
+      integer (kind=omp_control_tool_kind), parameter :: omp_control_tool_pause = 2
+      integer (kind=omp_control_tool_kind), parameter :: omp_control_tool_flush = 3
+      integer (kind=omp_control_tool_kind), parameter :: omp_control_tool_end = 4
+
+      integer (kind=omp_control_tool_result_kind), parameter :: omp_control_tool_notool = -2
+      integer (kind=omp_control_tool_result_kind), parameter :: omp_control_tool_nocallback = -1
+      integer (kind=omp_control_tool_result_kind), parameter :: omp_control_tool_success = 0
+      integer (kind=omp_control_tool_result_kind), parameter :: omp_control_tool_ignored = 1
 
       interface
 
@@ -493,6 +505,13 @@
           integer (kind=omp_nest_lock_kind) nvar
           integer (kind=omp_lock_hint_kind), value :: hint
         end subroutine omp_init_nest_lock_with_hint
+
+        function omp_control_tool(command, modifier) bind(c)
+          import
+          integer (kind=omp_integer_kind) omp_control_tool
+          integer (kind=omp_control_tool_kind), value :: command
+          integer (kind=omp_control_tool_kind), value :: modifier
+        end function omp_control_tool
 
       end interface
 


### PR DESCRIPTION
Add declaration of omp_control_tool in the Fortran headers.