### PR TITLE
Fixed build on Mac OS X

### DIFF
--- a/runtime/src/kmp_settings.cpp
+++ b/runtime/src/kmp_settings.cpp
@@ -336,13 +336,11 @@ static void __kmp_stg_parse_size(char const *name, char const *value,
   }; // if
 } // __kmp_stg_parse_size
 
-#if KMP_AFFINITY_SUPPORTED
 static void __kmp_stg_parse_str(char const *name, char const *value,
                                 char const **out) {
   __kmp_str_free(out);
   *out = __kmp_str_format("%s", value);
 } // __kmp_stg_parse_str
-#endif
 
 static void __kmp_stg_parse_int(
     char const

--- a/runtime/src/ompt-general.cpp
+++ b/runtime/src/ompt-general.cpp
@@ -548,7 +548,7 @@ OMPT_API_ROUTINE int ompt_get_partition_place_nums(int place_nums_size,
  ****************************************************************************/
 
 OMPT_API_ROUTINE int ompt_get_proc_id(void) {
-#ifdef KMP_OS_LINUX
+#if KMP_OS_LINUX
   return sched_getcpu();
 #else
   return -1;


### PR DESCRIPTION
1. **#if** KMP_OS_LINUX should be used because this macro is always defined but to 0 in case of non-Linux.
2. #if KMP_AFFINITY_SUPPORTED can be safely removed from __kmp_stg_parse_str() which is now used in __kmp_stg_parse_omp_tool_libraries().