### PR TITLE
include support for the following additional ICVs 

### DIFF
--- a/runtime/src/ompd-specific.h
+++ b/runtime/src/ompd-specific.h
@@ -130,6 +130,10 @@ OMPD_SIZEOF(ompt_data_t) \
 OMPD_SIZEOF(ompt_id_t) \
 OMPD_SIZEOF(__kmp_avail_proc) \
 OMPD_SIZEOF(__kmp_max_nth) \
+OMPD_SIZEOF(__kmp_stksize) \
+OMPD_SIZEOF(__kmp_omp_cancellation) \
+OMPD_SIZEOF(__kmp_max_task_priority) \
+OMPD_SIZEOF(ompd_state) \
 OMPD_SIZEOF(__kmp_gtid) \
 OMPD_SIZEOF(__kmp_nth) \
 OMPD_SIZEOF(ompd_cuda_context_ptr_t) \


### PR DESCRIPTION
in ompd_enumerate_icvs() and ompd_get_icv_from_scope():

dyn-var, stacksize-var, cancel-var, max-task-priority-var, debug-var

Patch provided by @jinisusan