### PR TITLE
Retrieval of ICVs: affinity-format-var, tool-libraries-var, default-device-var

### DIFF
--- a/libompd/src/TargetValue.cpp
+++ b/libompd/src/TargetValue.cpp
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include <cstring>
 
 const ompd_callbacks_t *TValue::callbacks = NULL;
 ompd_device_type_sizes_t TValue::type_sizes;
@@ -365,20 +366,27 @@ ompd_rc_t TValue::getString(const char **buf) {
   ompd_rc_t ret;
 #define BUF_LEN 512
   char *string_buffer;
-  ret = callbacks->alloc_memory(BUF_LEN, (void **)&string_buffer);
+
+  // Allocate an extra byte, but pass only BUF_LEN to the tool
+  // so that we can detect truncation later.
+  ret = callbacks->alloc_memory(BUF_LEN + 1, (void **)&string_buffer);
   if (ret != ompd_rc_ok) {
     return ret;
   }
+  string_buffer[BUF_LEN] = '\0';
 
   // TODO: if we have not read in the complete string, we need to realloc
   // 'string_buffer' and attempt reading again repeatedly till the entire string
   // is read in.
   ret = callbacks->read_string(context, tcontext,
                                &strValue.symbolAddr, BUF_LEN, (void *)string_buffer);
-  if (ret != ompd_rc_ok) {
-    string_buffer[BUF_LEN - 1] = '\0';
-  }
   *buf = string_buffer;
+  // Check for truncation. The standard specifies that if a null byte is not
+  // among the first 'nbytes' bytes, the string placed in the buffer is not
+  // null-terminated. 'nbytes' is BUF_LEN in this case.
+  if (ret == ompd_rc_ok && strlen(string_buffer) == BUF_LEN) {
+    return ompd_rc_error;
+  }
   return ret;
 }
 

--- a/libompd/src/TargetValue.h
+++ b/libompd/src/TargetValue.h
@@ -152,7 +152,11 @@ public:
    */
   ompd_rc_t getRawValue(void *buf, int count);
   /**
-   * Get a string copy from the target value
+   * Fetch a string copy from the target. "this" represents the pointer
+   * that holds the value of a null terminated character string. "buf"
+   * points to the destination string to be allocated and copied to.
+   * Returns 'ompd_rc_error' to signify a truncated string or a target
+   * read error.
    */
   ompd_rc_t getString(const char **buf);
   //   ompd_rc_t getAddress(struct ompd_handle* th) const;

--- a/libompd/src/TargetValue.h
+++ b/libompd/src/TargetValue.h
@@ -151,6 +151,10 @@ public:
    * Get the raw memory copy of the target value
    */
   ompd_rc_t getRawValue(void *buf, int count);
+  /**
+   * Get a string copy from the target value
+   */
+  ompd_rc_t getString(const char **buf);
   //   ompd_rc_t getAddress(struct ompd_handle* th) const;
   /**
    * Get a new target value object for the dereferenced target value

--- a/libompd/src/omp-icv.cpp
+++ b/libompd/src/omp-icv.cpp
@@ -137,6 +137,22 @@ ompd_rc_t ompd_enumerate_icvs(ompd_address_space_handle_t *handle,
   return ompd_rc_ok;
 }
 
+static ompd_rc_t create_empty_string(const char **empty_string_ptr) {
+  char *empty_str;
+  ompd_rc_t ret;
+
+  if (!callbacks) {
+    return ompd_rc_error;
+  }
+  ret = callbacks->alloc_memory(1, (void **)&empty_str);
+  if (ret != ompd_rc_ok) {
+    return ret;
+  }
+  empty_str[0] = '\0';
+  *empty_string_ptr = empty_str;
+  return ompd_rc_ok;
+}
+
 static ompd_rc_t ompd_get_dynamic(
     ompd_thread_handle_t *thread_handle, /* IN: OpenMP thread handle */
     ompd_word_t *dyn_val                 /* OUT: Dynamic adjustment of threads */
@@ -444,6 +460,9 @@ static ompd_rc_t ompd_get_tool_libraries(
   ret = TValue(context, "__kmp_tool_libraries")
             .cast("char", 1)
             .getString(tool_libraries_string);
+  if (ret == ompd_rc_unsupported) {
+    ret = create_empty_string(tool_libraries_string);
+  }
   return ret;
 }
 

--- a/libompd/src/omp-icv.cpp
+++ b/libompd/src/omp-icv.cpp
@@ -11,7 +11,10 @@
     macro (debug_var, "debug-var", ompd_scope_address_space, 0)                \
     macro (nthreads_var, "nthreads-var", ompd_scope_thread, 0)                 \
     macro (display_affinity_var, "display-affinity-var", ompd_scope_address_space, 0)    \
+    macro (affinity_format_var, "affinity-format-var", ompd_scope_address_space, 0)      \
+    macro (default_device_var, "default-device-var", ompd_scope_thread, 0)     \
     macro (tool_var, "tool-var", ompd_scope_address_space, 0)                  \
+    macro (tool_libraries_var, "tool-libraries-var", ompd_scope_address_space, 0)                  \
     macro (levels_var, "levels-var", ompd_scope_parallel, 1)                   \
     macro (active_levels_var, "active-levels-var", ompd_scope_parallel, 0)     \
     macro (thread_limit_var, "thread-limit-var", ompd_scope_address_space, 0)  \
@@ -388,6 +391,8 @@ static ompd_rc_t ompd_get_nthreads(
   }
 
   return ompd_rc_ok;
+}
+
 static ompd_rc_t ompd_get_display_affinity(
     ompd_address_space_handle_t *addr_handle, /* IN: handle for the address space */
     ompd_word_t *display_affinity_val         /* OUT: display affinity value */
@@ -403,6 +408,70 @@ static ompd_rc_t ompd_get_display_affinity(
   ret = TValue(context, "__kmp_display_affinity")
             .castBase("__kmp_display_affinity")
             .getValue(*display_affinity_val);
+  return ret;
+}
+
+static ompd_rc_t ompd_get_affinity_format(
+    ompd_address_space_handle_t *addr_handle, /* IN: address space handle*/
+    const char **affinity_format_string       /* OUT: affinity format string */
+    ) {
+  ompd_address_space_context_t *context = addr_handle->context;
+  if (!context)
+    return ompd_rc_stale_handle;
+
+  if (!callbacks) {
+    return ompd_rc_error;
+  }
+  ompd_rc_t ret;
+  ret = TValue(context, "__kmp_affinity_format")
+            .cast("char", 1)
+            .getString(affinity_format_string);
+  return ret;
+}
+
+static ompd_rc_t ompd_get_tool_libraries(
+    ompd_address_space_handle_t *addr_handle, /* IN: address space handle*/
+    const char **tool_libraries_string        /* OUT: tool libraries string */
+    ) {
+  ompd_address_space_context_t *context = addr_handle->context;
+  if (!context)
+    return ompd_rc_stale_handle;
+
+  if (!callbacks) {
+    return ompd_rc_error;
+  }
+  ompd_rc_t ret;
+  ret = TValue(context, "__kmp_tool_libraries")
+            .cast("char", 1)
+            .getString(tool_libraries_string);
+  return ret;
+}
+
+static ompd_rc_t ompd_get_default_device(
+    ompd_thread_handle_t *thread_handle, /* IN: handle for the thread */
+    ompd_word_t *default_device_val      /* OUT: default device value */
+    ) {
+  if (!thread_handle)
+    return ompd_rc_stale_handle;
+  if (!thread_handle->ah)
+    return ompd_rc_stale_handle;
+  ompd_address_space_context_t *context = thread_handle->ah->context;
+  if (!context)
+    return ompd_rc_stale_handle;
+  if (!callbacks)
+    return ompd_rc_error;
+
+  ompd_rc_t ret =
+      TValue(context, thread_handle->th) /*__kmp_threads[t]->th*/
+          .cast("kmp_base_info_t")
+          .access("th_current_task") /*__kmp_threads[t]->th.th_current_task*/
+          .cast("kmp_taskdata_t", 1)
+          .access("td_icvs") /*__kmp_threads[t]->th.th_current_task->td_icvs*/
+          .cast("kmp_internal_control_t", 0)
+          /*__kmp_threads[t]->th.th_current_task->td_icvs.default_device*/
+          .access("default_device")
+          .castBase()
+          .getValue(*default_device_val);
   return ret;
 }
 
@@ -796,6 +865,12 @@ ompd_rc_t ompd_get_icv_from_scope(void *handle, ompd_scope_t scope,
         return ompd_get_nthreads((ompd_thread_handle_t *)handle, icv_value);
       case ompd_icv_display_affinity_var:
         return ompd_get_display_affinity((ompd_address_space_handle_t *)handle, icv_value);
+      case ompd_icv_affinity_format_var:
+        return ompd_rc_incompatible;
+      case ompd_icv_tool_libraries_var:
+        return ompd_rc_incompatible;
+      case ompd_icv_default_device_var:
+        return ompd_get_default_device((ompd_thread_handle_t *)handle, icv_value);
       case ompd_icv_tool_var:
         return ompd_get_tool((ompd_address_space_handle_t *)handle, icv_value);
       case ompd_icv_levels_var:
@@ -871,6 +946,12 @@ ompd_get_icv_string_from_scope(void *handle, ompd_scope_t scope,
     switch (icv_id) {
       case ompd_icv_nthreads_var:
         return ompd_get_nthreads((ompd_thread_handle_t *)handle, icv_string);
+      case ompd_icv_affinity_format_var:
+        return ompd_get_affinity_format((ompd_address_space_handle_t *)handle,
+             icv_string);
+      case ompd_icv_tool_libraries_var:
+        return ompd_get_tool_libraries((ompd_address_space_handle_t *)handle,
+             icv_string);
       default:
         return ompd_rc_unsupported;
     }

--- a/runtime/src/kmp.h
+++ b/runtime/src/kmp.h
@@ -810,6 +810,9 @@ extern int __kmp_display_affinity;
 extern char *__kmp_affinity_format;
 static const size_t KMP_AFFINITY_FORMAT_SIZE = 512;
 extern int __kmp_tool;
+#if OMPT_SUPPORT
+extern char *__kmp_tool_libraries;
+#endif // OMPT_SUPPORT
 #endif // OMP_50_ENABLED
 
 #if KMP_AFFINITY_SUPPORTED

--- a/runtime/src/kmp_settings.cpp
+++ b/runtime/src/kmp_settings.cpp
@@ -4699,7 +4699,7 @@ static void __kmp_stg_print_omp_tool(kmp_str_buf_t *buffer, char const *name,
   }
 } // __kmp_stg_print_omp_tool
 
-static char *__kmp_tool_libraries = NULL;
+char *__kmp_tool_libraries = NULL;
 
 static void __kmp_stg_parse_omp_tool_libraries(char const *name,
                                                char const *value, void *data) {

--- a/runtime/src/ompd-specific.h
+++ b/runtime/src/ompd-specific.h
@@ -69,6 +69,7 @@ OMPD_ACCESS(kmp_internal_control_t, nested) \
 OMPD_ACCESS(kmp_internal_control_t, nproc) \
 OMPD_ACCESS(kmp_internal_control_t, proc_bind) \
 OMPD_ACCESS(kmp_internal_control_t, sched) \
+OMPD_ACCESS(kmp_internal_control_t, default_device) \
 \
 OMPD_ACCESS(kmp_taskdata_t,       ompt_task_info) \
 OMPD_ACCESS(kmp_taskdata_t,       td_flags) \
@@ -137,11 +138,14 @@ OMPD_SIZEOF(__kmp_stksize) \
 OMPD_SIZEOF(__kmp_omp_cancellation) \
 OMPD_SIZEOF(__kmp_max_task_priority) \
 OMPD_SIZEOF(__kmp_display_affinity) \
+OMPD_SIZEOF(__kmp_affinity_format) \
+OMPD_SIZEOF(__kmp_tool_libraries) \
 OMPD_SIZEOF(__kmp_tool) \
 OMPD_SIZEOF(ompd_state) \
 OMPD_SIZEOF(kmp_nested_nthreads_t) \
 OMPD_SIZEOF(__kmp_nested_nth) \
 OMPD_SIZEOF(int) \
+OMPD_SIZEOF(char) \
 OMPD_SIZEOF(__kmp_gtid) \
 OMPD_SIZEOF(__kmp_nth) \
 OMPD_SIZEOF(ompd_cuda_context_ptr_t) \


### PR DESCRIPTION
PR for adding support for retrieving ICV values: affinity-format-var, tool-libraries-var, default-device-var. Introduces TValue::getString() (which utilizes the read_string() tool callback routine) to get a string copy from a target value.  Though expensive, TValue::getString() uses repeated target reads to first count the number of characters in the string. 